### PR TITLE
Improve detection of project local advice

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,23 +34,27 @@ the need to modify their build, add the following to `~/.sbt/0.13/plugins/build.
 addSbtPlugin("com.softwaremill.clippy" % "plugin-sbt" % "0.3.0")
 ````
 
-Upon first use, the plugin will download the advice dataset from `https://scala-clippy.org` and store it in the 
+Upon first use, the plugin will download the advice dataset from `https://scala-clippy.org` and store it in the
 `$HOME/.clippy` directory. The dataset will be updated at most once a day, in the background. You can customize the
-dataset URL and local store by using the `-P:clippy:url=` and `-P:clippy:store=` compiler options. 
+dataset URL and local store by using the `-P:clippy:url=` and `-P:clippy:store=` compiler options.
 
 # Contributing advice
 
-Scala Clippy is only as good as its advice database. Help other users by submitting a fix for a compilation error that 
+Scala Clippy is only as good as its advice database. Help other users by submitting a fix for a compilation error that
 you have encountered!
 
-It will only take you a couple of minutes, no registration required. Just head over to 
+It will only take you a couple of minutes, no registration required. Just head over to
 [https://scala-clippy.org](https://scala-clippy.org)! Thanks!
 
 # Project specific advice
 
 If you have advice that you feel is too specific to be worth sharing on [https://scala-clippy.org](https://scala-clippy.org)
 you can add it to your project specific advice file.
-Just create a file named .clippy.json in the root of your project directory and add the advice json in the format illustrated below:
+First set your project root
+````
+scalacOptions += "-P:clippy:projectRoot=" + (baseDirectory in ThisBuild).value
+````
+Then create a file named .clippy.json in the root of your project directory and add the advice json in the format illustrated below:
 
 ````
 {

--- a/plugin-sbt/src/main/scala/com/softwaremill/clippy/ClippySbtPlugin.scala
+++ b/plugin-sbt/src/main/scala/com/softwaremill/clippy/ClippySbtPlugin.scala
@@ -1,12 +1,10 @@
 package com.softwaremill.clippy
 
 import sbt._
-import Keys._
 
 object ClippySbtPlugin extends AutoPlugin {
-  override lazy val projectSettings = Seq(
-    addCompilerPlugin("com.softwaremill.clippy" %% "plugin" % ClippyBuildInfo.version classifier "bundle"),
-    scalacOptions += "-P:clippy:projectRoot=" + (baseDirectory in ThisBuild).value
+  override def projectSettings = Seq(
+    addCompilerPlugin("com.softwaremill.clippy" %% "plugin" % ClippyBuildInfo.version classifier "bundle")
   )
 
   override def trigger = allRequirements

--- a/plugin-sbt/src/main/scala/com/softwaremill/clippy/ClippySbtPlugin.scala
+++ b/plugin-sbt/src/main/scala/com/softwaremill/clippy/ClippySbtPlugin.scala
@@ -1,10 +1,12 @@
 package com.softwaremill.clippy
 
 import sbt._
+import Keys._
 
 object ClippySbtPlugin extends AutoPlugin {
-  override def projectSettings = Seq(
-    addCompilerPlugin("com.softwaremill.clippy" %% "plugin" % ClippyBuildInfo.version classifier "bundle")
+  override lazy val projectSettings = Seq(
+    addCompilerPlugin("com.softwaremill.clippy" %% "plugin" % ClippyBuildInfo.version classifier "bundle"),
+    scalacOptions += "-P:clippy:projectRoot=" + (baseDirectory in ThisBuild).value
   )
 
   override def trigger = allRequirements


### PR DESCRIPTION
I believe this PR does a better job of detecting local advice including situations like when running IntelliJ's standalone compiler that has a different working directory than the project root.

When I publishLocal I do get an error that json4s cannot be found but I also get that when I republish version 2.5 or 3.0 so this does not appear to be a new behavior.