### PR TITLE
Add advice from resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ Then create a file named .clippy.json in the root of your project directory and 
   "version": "0.3.1",
   "advices": [
     {
-      "id": 2,
       "error": {
         "type": "typeMismatch",
         "found": "scala\\.concurrent\\.Future\\[Int\\]",
@@ -77,6 +76,15 @@ Then create a file named .clippy.json in the root of your project directory and 
   ]
 }
 ````
+
+# Library specific advice
+
+If you have advice that is specific to a library or library version you can also bundle the advice with your library.
+If your users have Scala-Clippy installed they will see your advice if your library is inclued in their project.
+This can be helpful in the common case where users of your library need specific imports to be able to use your functionality.
+To bundle clippy advice with your library just put it in a file named clippy.json in your resources directory
+
+For examples on how to write tests for advice to ensure it does not go out of date see [CompileTests.scala](./tests/src/test/scala/org/softwaremill/clippy/CompileTests.scala)
 
 # Alternative ways to use Clippy
 

--- a/model/src/main/scala/com/softwaremill/clippy/Advice.scala
+++ b/model/src/main/scala/com/softwaremill/clippy/Advice.scala
@@ -2,13 +2,12 @@ package com.softwaremill.clippy
 
 import org.json4s.JsonAST._
 
-case class Advice(id: Long, compilationError: CompilationError[RegexT], advice: String, library: Library) {
+case class Advice(compilationError: CompilationError[RegexT], advice: String, library: Library) {
   def errMatching: PartialFunction[CompilationError[ExactT], String] = {
     case ce if compilationError.matches(ce) => advice
   }
 
   def toJson: JValue = JObject(
-      "id" -> JInt(id),
       "error" -> compilationError.toJson,
       "text" -> JString(advice),
       "library" -> library.toJson
@@ -19,12 +18,11 @@ object Advice {
   def fromJson(jvalue: JValue): Option[Advice] = {
     (for {
       JObject(fields) <- jvalue
-      JField("id", JInt(id)) <- fields
       JField("error", errorJV) <- fields
       error <- CompilationError.fromJson(errorJV).toList
       JField("text", JString(text)) <- fields
       JField("library", libraryJV) <- fields
       library <- Library.fromJson(libraryJV).toList
-    } yield Advice(id.longValue(), error, text, library)).headOption
+    } yield Advice(error, text, library)).headOption
   }
 }

--- a/plugin/src/main/scala/com/softwaremill/clippy/Utils.scala
+++ b/plugin/src/main/scala/com/softwaremill/clippy/Utils.scala
@@ -1,6 +1,10 @@
 package com.softwaremill.clippy
 
 import java.io.{ByteArrayOutputStream, InputStream}
+import java.io.Closeable
+import scala.util.control.NonFatal
+import scala.util.{Failure, Try}
+
 
 object Utils {
   /**
@@ -40,5 +44,27 @@ object Utils {
       baos.toByteArray
     }
     finally is.close()
+  }
+
+  object TryWith {
+    def apply[C <: Closeable, R](resource: => C)(f: C => R): Try[R] =
+      Try(resource).flatMap(resourceInstance => {
+        try {
+          val returnValue = f(resourceInstance)
+          Try(resourceInstance.close()).map(_ => returnValue)
+        }
+        catch {
+          case NonFatal(exceptionInFunction) =>
+            try {
+              resourceInstance.close()
+              Failure(exceptionInFunction)
+            }
+            catch {
+              case NonFatal(exceptionInClose) =>
+                exceptionInFunction.addSuppressed(exceptionInClose)
+                Failure(exceptionInFunction)
+            }
+        }
+      })
   }
 }

--- a/tests/src/test/scala/org/softwaremill/clippy/CompileTests.scala
+++ b/tests/src/test/scala/org/softwaremill/clippy/CompileTests.scala
@@ -26,31 +26,27 @@ class CompileTests extends FlatSpec with Matchers with BeforeAndAfterAll {
 
     val advices = List(
       Advice(
-        1L,
         TypeMismatchError(ExactT("slick.dbio.DBIOAction[*]"), None, ExactT("slick.lifted.Rep[Option[*]]"), None).asRegex,
         "Perhaps you forgot to call .result on your Rep[]? This will give you a DBIOAction that you can compose with other DBIOActions.",
         Library("com.typesafe.slick", "slick", "3.1.0")
       ),
       Advice(
-        2L,
         TypeMismatchError(ExactT("akka.http.scaladsl.server.StandardRoute"), None, ExactT("akka.stream.scaladsl.Flow[akka.http.scaladsl.model.HttpRequest,akka.http.scaladsl.model.HttpResponse,Any]"), None).asRegex,
         "did you forget to define an implicit akka.stream.ActorMaterializer? It allows routes to be converted into a flow. You can read more at http://doc.akka.io/docs/akka-stream-and-http-experimental/2.0/scala/http/routing-dsl/index.html",
         Library("com.typesafe.akka", "akka-http-experimental", "2.0.0")
       ),
       Advice(
-        3L,
         NotFoundError(ExactT("value wire")).asRegex,
         "you need to import com.softwaremill.macwire._",
         Library("com.softwaremill.macwire", "macros", "2.0.0")
       ),
       Advice(
-        4L,
         TypeArgumentsDoNotConformToOverloadedBoundsError(
-          ExactT("*"), ExactT("value apply"), Set(
-            ExactT("[E <: slick.lifted.AbstractTable[_]]=> slick.lifted.TableQuery[E]"),
-            ExactT("[E <: slick.lifted.AbstractTable[_]](cons: slick.lifted.Tag => E)slick.lifted.TableQuery[E]")
-          )
-        ).asRegex,
+        ExactT("*"), ExactT("value apply"), Set(
+          ExactT("[E <: slick.lifted.AbstractTable[_]]=> slick.lifted.TableQuery[E]"),
+          ExactT("[E <: slick.lifted.AbstractTable[_]](cons: slick.lifted.Tag => E)slick.lifted.TableQuery[E]")
+        )
+      ).asRegex,
         "incorrect class name passed to TableQuery",
         Library("com.typesafe.slick", "slick", "3.1.1")
       )

--- a/ui/app/dal/AdvicesRepository.scala
+++ b/ui/app/dal/AdvicesRepository.scala
@@ -54,7 +54,7 @@ class AdvicesRepository(database: SqlDatabase, idGenerator: IdGenerator)(implici
 case class StoredAdvice(id: Long, errorTextRaw: String, patternRaw: String, compilationError: CompilationError[RegexT],
     advice: String, state: AdviceState, library: Library, contributor: Contributor, comment: Option[String]) {
 
-  def toAdvice = Advice(id, compilationError, advice, library)
+  def toAdvice = Advice(compilationError, advice, library)
   def toAdviceListing = AdviceListing(id, compilationError, advice, library,
     ContributorListing(contributor.github, contributor.twitter))
 }


### PR DESCRIPTION
This pr updates clippy to collect advice from all clippy.json files in resources.
It also returns all matching advice, that way if multiple library authors register help for the same message (say .toJson not found) then we can display all of their advice and allow the user to choose.  