### PR TITLE
Load custom reporter in a plugin component

### DIFF
--- a/model/src/main/scala/com/softwaremill/clippy/StringDiff.scala
+++ b/model/src/main/scala/com/softwaremill/clippy/StringDiff.scala
@@ -3,10 +3,8 @@ package com.softwaremill.clippy
 import com.softwaremill.clippy.StringDiff.{DeltaEnd, DeltaStart}
 
 object StringDiff {
-  val AnsiReset = "\u001B[0m"
-  val AnsiRed = "\u001B[31m"
-  val DeltaEnd = AnsiReset
-  val DeltaStart = AnsiRed
+  val DeltaEnd = Console.RESET
+  val DeltaStart = Console.RED
 }
 
 class StringDiff(expected: String, actual: String) {

--- a/plugin/src/main/scala/com/softwaremill/clippy/InjectReporter.scala
+++ b/plugin/src/main/scala/com/softwaremill/clippy/InjectReporter.scala
@@ -1,0 +1,27 @@
+package com.softwaremill.clippy
+
+import scala.reflect.internal.util.Position
+import scala.tools.nsc.plugins.PluginComponent
+import scala.tools.nsc.{Global, Phase}
+
+class InjectReporter(handleError: (Position, String) => String, superGlobal: Global) extends PluginComponent {
+
+  override val global = superGlobal
+
+  override val runsAfter = List[String](" parser")
+  override val runsBefore = List[String]("namer")
+  override val phaseName = "inject-clippy-reporter"
+
+  override def newPhase(prev: Phase) = new Phase(prev) {
+
+    override def name = phaseName
+
+    override def description = "Switches the reporter to Clippy's DelegatingReporter"
+
+    override def run(): Unit = {
+      val r = global.reporter
+      global.reporter = new DelegatingReporter(r, handleError)
+    }
+  }
+
+}

--- a/plugin/src/main/scala/com/softwaremill/clippy/InjectReporter.scala
+++ b/plugin/src/main/scala/com/softwaremill/clippy/InjectReporter.scala
@@ -8,7 +8,7 @@ class InjectReporter(handleError: (Position, String) => String, superGlobal: Glo
 
   override val global = superGlobal
 
-  override val runsAfter = List[String](" parser")
+  override val runsAfter = List[String]("parser")
   override val runsBefore = List[String]("namer")
   override val phaseName = "inject-clippy-reporter"
 


### PR DESCRIPTION
Direct assignment of our reporter into the global reporter field results in occasional sbt exceptions like:
```
java.lang.ClassCastException: com.softwaremill.clippy.DelegatingReporter cannot be cast to xsbt.DelegatingReporter
       at xsbt.CachedCompiler0$Compiler.logUnreportedWarnings(CompilerInterface.scala:224)                          
        at xsbt.CachedCompiler0.processUnreportedWarnings(CompilerInterface.scala:145)                               
        at xsbt.CachedCompiler0.run(CompilerInterface.scala:117)                                                     
        at xsbt.CachedCompiler0.run(CompilerInterface.scala:95)                                                      
        at xsbt.CompilerInterface.run(CompilerInterface.scala:26)           
```
It's caused by sbt delegating reporter doing a direct cast of global reporter in the `CachedCompiler.logUnreportedWarnings` functions. 
This PR introduces a custom compilation phase injected between `parser` and `namer`. This phase will replace global repoter with Clippy's one and looks like SBT won't do the casting afterwards.

However, our custom phase won't get injected when compilation is started from tests, so I added another "undocumented" plugin option `testmode`. When `true`, the reporter assignment will happen as previously.