### PR TITLE
Restore original reporter after compilation

### DIFF
--- a/plugin/src/main/scala/com/softwaremill/clippy/ClippyPlugin.scala
+++ b/plugin/src/main/scala/com/softwaremill/clippy/ClippyPlugin.scala
@@ -54,7 +54,7 @@ class ClippyPlugin(val global: Global) extends Plugin {
     }
   }
 
-  override val components: List[PluginComponent] = List(new InjectReporter(handleError, global))
+  override val components: List[PluginComponent] = List(new InjectReporter(handleError, global), new RestoreReporter(global))
 
   private def prettyPrintTypeMismatchError(tme: TypeMismatchError[ExactT], msg: String): String = {
     val plain = new StringDiff(tme.required.toString, tme.found.toString)

--- a/plugin/src/main/scala/com/softwaremill/clippy/InjectReporter.scala
+++ b/plugin/src/main/scala/com/softwaremill/clippy/InjectReporter.scala
@@ -4,6 +4,9 @@ import scala.reflect.internal.util.Position
 import scala.tools.nsc.plugins.PluginComponent
 import scala.tools.nsc.{Global, Phase}
 
+/**
+  * Responsible for replacing the global reporter with our custom Clippy reporter after the first phase of compilation.
+  */
 class InjectReporter(handleError: (Position, String) => String, superGlobal: Global) extends PluginComponent {
 
   override val global = superGlobal

--- a/plugin/src/main/scala/com/softwaremill/clippy/RestoreReporter.scala
+++ b/plugin/src/main/scala/com/softwaremill/clippy/RestoreReporter.scala
@@ -1,0 +1,26 @@
+package com.softwaremill.clippy
+
+import scala.reflect.internal.util.Position
+import scala.tools.nsc.plugins.PluginComponent
+import scala.tools.nsc.{Global, Phase}
+
+class RestoreReporter(val global: Global) extends PluginComponent {
+
+  val originalReporter = global.reporter
+
+  override val runsAfter = List[String]("jvm")
+  override val runsBefore = List[String]("terminal")
+  override val phaseName = "restore-original-reporter"
+
+  override def newPhase(prev: Phase) = new Phase(prev) {
+
+    override def name = phaseName
+
+    override def description = "Switches the reporter from Clippy's DelegatingReporter back to original one"
+
+    override def run(): Unit = {
+      global.reporter = originalReporter
+    }
+  }
+
+}

--- a/plugin/src/main/scala/com/softwaremill/clippy/RestoreReporter.scala
+++ b/plugin/src/main/scala/com/softwaremill/clippy/RestoreReporter.scala
@@ -1,9 +1,13 @@
 package com.softwaremill.clippy
 
-import scala.reflect.internal.util.Position
 import scala.tools.nsc.plugins.PluginComponent
 import scala.tools.nsc.{Global, Phase}
 
+/**
+  * Replaces global reporter back with the original global reporter. Sbt uses its own xsbt.DelegatingReporter
+  * which we cannot replace outside of Scala compilation phases. This component makes sure that before the compilation
+  * is over, original reporter gets reassigned to the global field.
+  */
 class RestoreReporter(val global: Global) extends PluginComponent {
 
   val originalReporter = global.reporter


### PR DESCRIPTION
- In multi-module sbt projects the build system needs its original reporter back between subsequent module compilations.