### PR TITLE
Better highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,11 @@ You can also help developing the plugin and/or the UI for submitting new advices
 * `ui-client` - the Scala.JS client-side code
 * `ui-shared` - code shared between the UI server and UI client (but not needed for the plugin)
 
+If you want to write your own tests with compilation using `mkToolbox`, remember to add a `-P:clippy:testmode=true`
+compiler option. It ensuers that a correct reporter replacement mechanism is used, which needs to be different
+specifically for tests. See [CompileTests.scala](tests/src/test/scala/org/softwaremill/clippy/CompileTests.scala) for
+reference.
+
 To publish locally append "-SNAPSHOT" to the version number then run
 ````scala
 sbt "project plugin" "+ publishLocal"

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ val json4s = "org.json4s" %% "json4s-native" % "3.4.2"
 
 // testing
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.1" % "test"
-val scalacheck = "org.scalacheck" %% "scalacheck" % "1.12.6" % "test"
+val scalacheck = "org.scalacheck" %% "scalacheck" % "1.13.4" % "test"
 
 name := "clippy"
 

--- a/model/src/main/scala/com/softwaremill/clippy/CompilationError.scala
+++ b/model/src/main/scala/com/softwaremill/clippy/CompilationError.scala
@@ -43,6 +43,8 @@ case class TypeMismatchError[T <: Template](found: T, foundExpandsTo: Option[T],
       false
   }
 
+  def hasExpands: Boolean = foundExpandsTo.nonEmpty || requiredExpandsTo.nonEmpty
+
   override def asRegex(implicit ev: T =:= ExactT) = TypeMismatchError(
     RegexT.fromPattern(found.v), foundExpandsTo.map(fe => RegexT.fromPattern(fe.v)),
     RegexT.fromPattern(required.v), requiredExpandsTo.map(re => RegexT.fromPattern(re.v)))

--- a/model/src/main/scala/com/softwaremill/clippy/StringDiff.scala
+++ b/model/src/main/scala/com/softwaremill/clippy/StringDiff.scala
@@ -1,14 +1,14 @@
 package com.softwaremill.clippy
 
-import com.softwaremill.clippy.StringDiff.{DeltaEnd, DeltaStart}
-
 object StringDiff {
   val DeltaEnd = Console.RESET
   val DeltaStart = Console.RED
+  val separators = List(' ', ',', '(', ')', '[', ']', '#', '#', '=', '>', '{')
+  def isSeparator(char: Char) = separators.contains(char)
 }
 
 class StringDiff(expected: String, actual: String) {
-
+  import StringDiff._
   def diff(message: String): String = {
     if (this.expected == this.actual) format(message, this.expected, this.actual)
     else format(message, markDiff(expected), markDiff(actual))
@@ -25,10 +25,19 @@ class StringDiff(expected: String, actual: String) {
     prefix + diff + suffix
   }
 
-  private def findCommonPrefix(expectedStr: String = expected, actualStr: String = actual): String = {
-    expectedStr.zip(actualStr).takeWhile(Function.tupled(_ == _)).map(_._1).mkString
+  def findCommonPrefix(expectedStr: String = expected, actualStr: String = actual): String = {
+    val prefixChars = expectedStr.zip(actualStr).takeWhile(Function.tupled(_ == _)).map(_._1)
+
+    val lastSeparatorIndex = prefixChars.lastIndexWhere(isSeparator)
+    val prefixStartIndex = if (lastSeparatorIndex == -1) 0 else lastSeparatorIndex + 1
+
+    if (prefixChars.nonEmpty && prefixStartIndex < prefixChars.length)
+      prefixChars.mkString.substring(0, prefixStartIndex)
+    else {
+      prefixChars.mkString
+    }
   }
 
-  private def findCommonSuffix(): String =
+  def findCommonSuffix(): String =
     findCommonPrefix(expected.reverse, actual.reverse).reverse
 }

--- a/model/src/main/scala/com/softwaremill/clippy/StringDiff.scala
+++ b/model/src/main/scala/com/softwaremill/clippy/StringDiff.scala
@@ -14,8 +14,6 @@ class StringDiff(expected: String, actual: String) {
     else format(message, markDiff(expected), markDiff(actual))
   }
 
-  def isEmpty: Boolean = expected == actual
-
   private def format(msg: String, expected: String, actual: String) = msg.format(expected, actual)
 
   private def markDiff(source: String) = {

--- a/model/src/main/scala/com/softwaremill/clippy/StringDiff.scala
+++ b/model/src/main/scala/com/softwaremill/clippy/StringDiff.scala
@@ -3,7 +3,7 @@ package com.softwaremill.clippy
 object StringDiff {
   val DeltaEnd = Console.RESET
   val DeltaStart = Console.RED
-  val separators = List(' ', ',', '(', ')', '[', ']', '#', '#', '=', '>', '{')
+  val separators = List(' ', ',', '(', ')', '[', ']', '#', '#', '=', '>', '{', '.')
   def isSeparator(char: Char) = separators.contains(char)
 }
 

--- a/model/src/main/scala/com/softwaremill/clippy/StringDiff.scala
+++ b/model/src/main/scala/com/softwaremill/clippy/StringDiff.scala
@@ -14,6 +14,8 @@ class StringDiff(expected: String, actual: String) {
     else format(message, markDiff(expected), markDiff(actual))
   }
 
+  def isEmpty: Boolean = expected == actual
+
   private def format(msg: String, expected: String, actual: String) = msg.format(expected, actual)
 
   private def markDiff(source: String) = {

--- a/model/src/test/scala/com/softwaremill/clippy/StringDiffSpecification.scala
+++ b/model/src/test/scala/com/softwaremill/clippy/StringDiffSpecification.scala
@@ -1,0 +1,53 @@
+package com.softwaremill.clippy
+
+import org.scalacheck.Prop.forAll
+import org.scalacheck.Properties
+
+class StringDiffSpecification extends Properties("StringDiff") with TypeNamesGenerators {
+
+  val S = StringDiff.DeltaStart
+  val E = StringDiff.DeltaEnd
+
+  def innerTypeDiffsCorrectly(fourTypes: List[String]): Boolean = {
+    val List(x, y, v, z) = fourTypes
+    val expected = s"$x[$y[$z]]"
+    val actual = s"$x[$v[$z]]"
+    val msg = new StringDiff(expected, actual).diff("expected: %s actual: %s")
+    msg == s"""expected: $x[$S$y$E[$z]] actual: $x[$S$v$E[$z]]"""
+  }
+
+  def twoTypesAreFullyDiff(twoTypes: List[String]): Boolean = {
+    val List(x, y) = twoTypes
+    new StringDiff(x, y).diff("expected: %s actual: %s") == s"""expected: $S$x$E actual: $S$y$E"""
+  }
+
+  property("X[Y[Z]] vs X[V[Z]] always gives X[<diff>[Z]]") =
+    forAll(different(singleTypeName)(4))(innerTypeDiffsCorrectly)
+
+  property("X[Y[Z]] vs X[V[Z]] always gives X[<diff>[Z]] if Y and V have common prefix") =
+    forAll(typesWithCommonPrefix(4))(innerTypeDiffsCorrectly)
+
+  property("X[Y[Z]] vs X[V[Z]] always gives X[<diff>[Z]] if Y and V have common suffix") =
+    forAll(typesWithCommonSuffix(4))(innerTypeDiffsCorrectly)
+
+  property("A[X] vs B[X] always marks outer as diff for A != B when A and B have common prefix") =
+    forAll(typesWithCommonPrefix(2), complexTypeName(maxDepth = 3)) { (outerTypes, x) =>
+      val List(a, b) = outerTypes
+      val expected = s"$a[$x]"
+      val actual = s"$b[$x]"
+      val msg = new StringDiff(expected, actual).diff("expected: %s actual: %s")
+      msg == s"""expected: $S$a$E[$x] actual: $S$b$E[$x]"""
+    }
+
+  property("any complex X vs Y is a full diff when X and Y don't have common suffix nor prefix") =
+    forAll(different(complexTypeName(maxDepth = 4))(2).suchThat(noCommonPrefixSuffix))(twoTypesAreFullyDiff)
+
+  property("any single X vs Y is a full diff") =
+    forAll(different(singleTypeName)(2))(twoTypesAreFullyDiff)
+
+  def noCommonPrefixSuffix(twoTypes: List[String]): Boolean = {
+    val List(x, y) = twoTypes
+    x.head != y.head && x.last != y.last
+  }
+
+}

--- a/model/src/test/scala/com/softwaremill/clippy/StringDiffSpecification.scala
+++ b/model/src/test/scala/com/softwaremill/clippy/StringDiffSpecification.scala
@@ -21,7 +21,7 @@ class StringDiffSpecification extends Properties("StringDiff") with TypeNamesGen
     new StringDiff(x, y).diff("expected: %s actual: %s") == s"""expected: $S$x$E actual: $S$y$E"""
   }
 
-  property("X[Y[Z]] vs X[V[Z]] always gives X[<diff>[Z]]") =
+  property("X[Y[Z]] vs X[V[Z]] always gives X[<diff>[Z]] excluding packages") =
     forAll(different(singleTypeName)(4))(innerTypeDiffsCorrectly)
 
   property("X[Y[Z]] vs X[V[Z]] always gives X[<diff>[Z]] if Y and V have common prefix") =
@@ -37,6 +37,15 @@ class StringDiffSpecification extends Properties("StringDiff") with TypeNamesGen
       val actual = s"$b[$x]"
       val msg = new StringDiff(expected, actual).diff("expected: %s actual: %s")
       msg == s"""expected: $S$a$E[$x] actual: $S$b$E[$x]"""
+    }
+
+  property("package.A[X] vs package.B[X] always gives package.<diff>A</diff>[X]") =
+    forAll(javaPackage, different(singleTypeName)(2), complexTypeName(maxDepth = 3)) { (pkg, outerTypes, x) =>
+      val List(a, b) = outerTypes
+      val expected = s"$pkg$a[$x]"
+      val actual = s"$pkg$b[$x]"
+      val msg = new StringDiff(expected, actual).diff("expected: %s actual: %s")
+      msg == s"""expected: $pkg$S$a$E[$x] actual: $pkg$S$b$E[$x]"""
     }
 
   property("any complex X vs Y is a full diff when X and Y don't have common suffix nor prefix") =

--- a/model/src/test/scala/com/softwaremill/clippy/StringDiffTest.scala
+++ b/model/src/test/scala/com/softwaremill/clippy/StringDiffTest.scala
@@ -20,4 +20,8 @@ class StringDiffTest extends FlatSpec with Matchers {
     }
   }
 
+  it should "be considered empty for equal expected and actal texts" in {
+    new StringDiff("None", "None") should be('empty)
+  }
+
 }

--- a/model/src/test/scala/com/softwaremill/clippy/StringDiffTest.scala
+++ b/model/src/test/scala/com/softwaremill/clippy/StringDiffTest.scala
@@ -8,7 +8,8 @@ class StringDiffTest extends FlatSpec with Matchers {
   val testData = List(
     ("Super[String, String]", "Super[Option[String], String]", "expected Super[" + DeltaStart + "String" + DeltaEnd + ", String] but was Super[" + DeltaStart + "Option[String]" + DeltaEnd + ", String]"),
     ("Cool[String, String]", "Super[Option[String], String]", "expected " + DeltaStart + "Cool[String" + DeltaEnd + ", String] but was " + DeltaStart + "Super[Option[String]" + DeltaEnd + ", String]"),
-    ("(String, String)", "Super[Option[String], String]", "expected " + DeltaStart + "(String, String)" + DeltaEnd + " but was " + DeltaStart + "Super[Option[String], String]" + DeltaEnd)
+    ("(String, String)", "Super[Option[String], String]", "expected " + DeltaStart + "(String, String)" + DeltaEnd + " but was " + DeltaStart + "Super[Option[String], String]" + DeltaEnd),
+    ("Map[Long, Double]", "Map[String, Double]", "expected Map[" + DeltaStart + "Long" + DeltaEnd + ", Double] but was Map[" + DeltaStart + "String" + DeltaEnd + ", Double]")
   )
 
   "StringDiff" should "diff" in {
@@ -24,4 +25,11 @@ class StringDiffTest extends FlatSpec with Matchers {
     new StringDiff("None", "None") should be('empty)
   }
 
+  it should "find common prefix" in {
+    new StringDiff("Map[Long, Double]", "Map[String, Double]").findCommonPrefix() should be("Map[")
+  }
+
+  it should "find common suffix" in {
+    new StringDiff("Map[Long, Double]", "Map[String, Double]").findCommonSuffix() should be(", Double]")
+  }
 }

--- a/model/src/test/scala/com/softwaremill/clippy/StringDiffTest.scala
+++ b/model/src/test/scala/com/softwaremill/clippy/StringDiffTest.scala
@@ -21,10 +21,6 @@ class StringDiffTest extends FlatSpec with Matchers {
     }
   }
 
-  it should "be considered empty for equal expected and actal texts" in {
-    new StringDiff("None", "None") should be('empty)
-  }
-
   it should "find common prefix" in {
     new StringDiff("Map[Long, Double]", "Map[String, Double]").findCommonPrefix() should be("Map[")
   }

--- a/model/src/test/scala/com/softwaremill/clippy/TypeNamesGenerators.scala
+++ b/model/src/test/scala/com/softwaremill/clippy/TypeNamesGenerators.scala
@@ -1,0 +1,107 @@
+package com.softwaremill.clippy
+
+import org.scalacheck.Gen
+
+trait TypeNamesGenerators {
+
+  import Gen._
+
+  def typeNameChar = frequency((1, numChar), (3, Gen.const('_')), (14, alphaChar))
+
+  val specialTypeName = Gen.oneOf(List("Option", "Operation", "Op", "String", "Long", "Set", "Aux"))
+
+  def javaPackage: Gen[String] = for {
+    depth <- Gen.choose(0, 3)
+    names <- Gen.listOfN(depth, packageIdentifer)
+  }
+    yield {
+      val str = names.filter(_.nonEmpty).mkString(".")
+      if (str.nonEmpty)
+        str + "."
+      else
+        str
+    }
+
+  def packageIdentifer: Gen[String] = for {
+    c <- alphaLowerChar
+    cs <- Gen.resize(7, listOf(alphaNumChar))
+    } yield {
+    (c :: cs).mkString
+  }
+
+  def randomTypeName: Gen[String] = for {
+    p <- javaPackage
+    c <- alphaChar
+    cs <- Gen.resize(7, listOf(typeNameChar))
+  } yield p + (c :: cs).mkString
+
+  def singleTypeName = frequency((3, randomTypeName), (7, specialTypeName))
+
+  def functionalTypeName(maxResultDepth: Int): Gen[String] = for {
+    argsMemberCount <- Gen.choose(2, 4)
+    args <- Gen.oneOf(singleTypeName, tupleTypeName(depth = 0, argsMemberCount))
+    result <- complexTypeName(maxResultDepth)
+  }
+    yield {
+      s"$args => $result"
+    }
+
+  def genericTypeName(depth: Int, memberCount: Int): Gen[String] = for {
+    name <- singleTypeName
+    innerNames <- Gen.listOfN(memberCount, if (depth == 0) singleTypeName else complexTypeName(depth - 1))
+  }
+    yield s"$name[${innerNames.mkString(", ")}]"
+
+  def tupleTypeName(depth: Int, memberCount: Int): Gen[String] = for {
+    innerNames <- Gen.listOfN(memberCount, if (depth == 0) singleTypeName else complexTypeName(depth - 1))
+  }
+    yield s"(${innerNames.mkString(", ")})"
+
+
+  def different[T](gen :Gen[T]) = (count: Int) => Gen.listOfN(count, gen).suchThat {
+    list =>list.distinct == list
+  }
+
+  def typesWithCommonPrefix = (count: Int) => for {
+    types <- different(singleTypeName)(count)
+    commonPrefix <- singleTypeName
+  } yield types.map(commonPrefix + _)
+
+  def typesWithCommonSuffix = (count: Int) => for {
+    types <- different(singleTypeName)(count)
+    commonSuffix <- singleTypeName
+  } yield types.map(_ + commonSuffix)
+
+  def flatTypeIdentifier = for {
+    tupleMemberCount <- Gen.choose(2, 4)
+    generator <- Gen.oneOf(Seq(singleTypeName, tupleTypeName(0, tupleMemberCount), innerTypeName(0), functionalTypeName(0)))
+    typeStr <- generator
+  }
+    yield typeStr
+
+  def deepTypeName(maxDepth: Int): Gen[String] = for {
+    genericMemberCount <- Gen.choose(1, 3)
+    tupleMemberCount <- Gen.choose(2, 4)
+    generator <- Gen.oneOf(Seq(
+      singleTypeName,
+      tupleTypeName(maxDepth, tupleMemberCount),
+      genericTypeName(maxDepth, genericMemberCount),
+      innerTypeName(maxDepth),
+      functionalTypeName(maxDepth)))
+    typeStr <- generator
+  }
+    yield typeStr
+
+  def complexTypeName(maxDepth: Int): Gen[String] = {
+    if (maxDepth == 0)
+      flatTypeIdentifier
+    else
+      deepTypeName(maxDepth)
+  }
+
+  def innerTypeName(maxDepth: Int): Gen[String] = for {
+    outerName <- singleTypeName
+    innerType <- complexTypeName(maxDepth)
+  }
+    yield s"$outerName#$innerType"
+}

--- a/model/src/test/scala/com/softwaremill/clippy/TypeNamesGenerators.scala
+++ b/model/src/test/scala/com/softwaremill/clippy/TypeNamesGenerators.scala
@@ -29,11 +29,15 @@ trait TypeNamesGenerators {
     (c :: cs).mkString
   }
 
-  def randomTypeName: Gen[String] = for {
+  def randomTypeWithPackage: Gen[String] = for {
     p <- javaPackage
+    t <- randomTypeWithPackage
+  } yield p + t
+
+  def randomTypeName: Gen[String] = for {
     c <- alphaChar
     cs <- Gen.resize(7, listOf(typeNameChar))
-  } yield p + (c :: cs).mkString
+  } yield (c :: cs).mkString
 
   def singleTypeName = frequency((3, randomTypeName), (7, specialTypeName))
 

--- a/plugin/src/main/scala/com/softwaremill/clippy/ClippyPlugin.scala
+++ b/plugin/src/main/scala/com/softwaremill/clippy/ClippyPlugin.scala
@@ -64,13 +64,15 @@ class ClippyPlugin(val global: Global) extends Plugin {
 
   private def prettyPrintTypeMismatchError(tme: TypeMismatchError[ExactT], msg: String): String = {
     val plain = new StringDiff(tme.required.toString, tme.found.toString)
-    val expands = new StringDiff(tme.requiredExpandsTo.toString, tme.foundExpandsTo.toString)
 
-    val expandsMsg =
-      if (expands.isEmpty)
-        ""
-      else
-        s"""${expands.diff("\nExpanded types:\nfound   : %s\\nrequired: %s\"")}"""
+    val expandsMsg = if (tme.hasExpands) {
+      val reqExpandsTo = tme.requiredExpandsTo.getOrElse(tme.required)
+      val foundExpandsTo = tme.foundExpandsTo.getOrElse(tme.found)
+      val expands = new StringDiff(reqExpandsTo.toString, foundExpandsTo.toString)
+      s"""${expands.diff("\nExpanded types:\nfound   : %s\nrequired: %s\"")}"""
+    }
+    else
+      ""
 
     s""" type mismatch;
          | Clippy advises:

--- a/plugin/src/main/scala/com/softwaremill/clippy/ClippyPlugin.scala
+++ b/plugin/src/main/scala/com/softwaremill/clippy/ClippyPlugin.scala
@@ -54,7 +54,12 @@ class ClippyPlugin(val global: Global) extends Plugin {
     }
   }
 
-  override val components: List[PluginComponent] = List(new InjectReporter(handleError, global), new RestoreReporter(global))
+  override val components: List[PluginComponent] = List(
+    new InjectReporter(handleError, global) {
+    override def enabled = !testMode
+  }, new RestoreReporter(global) {
+    override def enabled = !testMode
+  })
 
   private def prettyPrintTypeMismatchError(tme: TypeMismatchError[ExactT], msg: String): String = {
     val plain = new StringDiff(tme.required.toString, tme.found.toString)

--- a/plugin/src/main/scala/com/softwaremill/clippy/ClippyPlugin.scala
+++ b/plugin/src/main/scala/com/softwaremill/clippy/ClippyPlugin.scala
@@ -56,10 +56,11 @@ class ClippyPlugin(val global: Global) extends Plugin {
 
   override val components: List[PluginComponent] = List(
     new InjectReporter(handleError, global) {
-    override def enabled = !testMode
-  }, new RestoreReporter(global) {
-    override def enabled = !testMode
-  })
+      override def enabled = !testMode
+    }, new RestoreReporter(global) {
+      override def enabled = !testMode
+    }
+  )
 
   private def prettyPrintTypeMismatchError(tme: TypeMismatchError[ExactT], msg: String): String = {
     val plain = new StringDiff(tme.required.toString, tme.found.toString)

--- a/plugin/src/main/scala/com/softwaremill/clippy/ClippyPlugin.scala
+++ b/plugin/src/main/scala/com/softwaremill/clippy/ClippyPlugin.scala
@@ -56,9 +56,9 @@ class ClippyPlugin(val global: Global) extends Plugin {
 
   override val components: List[PluginComponent] = List(
     new InjectReporter(handleError, global) {
-      override def enabled = !testMode
+      override def isEnabled = !testMode
     }, new RestoreReporter(global) {
-      override def enabled = !testMode
+      override def isEnabled = !testMode
     }
   )
 

--- a/plugin/src/main/scala/com/softwaremill/clippy/ClippyPlugin.scala
+++ b/plugin/src/main/scala/com/softwaremill/clippy/ClippyPlugin.scala
@@ -59,15 +59,17 @@ class ClippyPlugin(val global: Global) extends Plugin {
   private def prettyPrintTypeMismatchError(tme: TypeMismatchError[ExactT], msg: String): String = {
     val plain = new StringDiff(tme.required.toString, tme.found.toString)
     val expands = new StringDiff(tme.requiredExpandsTo.toString, tme.foundExpandsTo.toString)
-    val finalMsg =
-      s"""
-         | $msg
+
+    val expandsMsg =
+      if (expands.isEmpty)
+        ""
+      else
+        s"""${expands.diff("\nExpanded types:\nfound   : %s\\nrequired: %s\"")}"""
+
+    s""" type mismatch;
          | Clippy advises:
-         | Type mismatch error, pay attention to the parts marked in red:
-         |          ${plain.diff("Types: required %s found %s")}
-         | ${expands.diff("Expanded types: required %s found %s")}
-                """.stripMargin
-    finalMsg
+         | Pay attention to the parts marked in red:
+         | ${plain.diff("found   : %s\n required: %s")}$expandsMsg""".stripMargin
   }
 
   private def urlFromOptions(options: List[String]): String =

--- a/plugin/src/main/scala/com/softwaremill/clippy/InjectReporter.scala
+++ b/plugin/src/main/scala/com/softwaremill/clippy/InjectReporter.scala
@@ -10,7 +10,7 @@ import scala.tools.nsc.{Global, Phase}
 class InjectReporter(handleError: (Position, String) => String, superGlobal: Global) extends PluginComponent {
 
   override val global = superGlobal
-
+  def isEnabled: Boolean = true
   override val runsAfter = List[String]("parser")
   override val runsBefore = List[String]("namer")
   override val phaseName = "inject-clippy-reporter"
@@ -22,8 +22,10 @@ class InjectReporter(handleError: (Position, String) => String, superGlobal: Glo
     override def description = "Switches the reporter to Clippy's DelegatingReporter"
 
     override def run(): Unit = {
-      val r = global.reporter
-      global.reporter = new DelegatingReporter(r, handleError)
+      if (isEnabled) {
+        val r = global.reporter
+        global.reporter = new DelegatingReporter(r, handleError)
+      }
     }
   }
 

--- a/plugin/src/main/scala/com/softwaremill/clippy/InjectReporter.scala
+++ b/plugin/src/main/scala/com/softwaremill/clippy/InjectReporter.scala
@@ -5,8 +5,8 @@ import scala.tools.nsc.plugins.PluginComponent
 import scala.tools.nsc.{Global, Phase}
 
 /**
-  * Responsible for replacing the global reporter with our custom Clippy reporter after the first phase of compilation.
-  */
+ * Responsible for replacing the global reporter with our custom Clippy reporter after the first phase of compilation.
+ */
 class InjectReporter(handleError: (Position, String) => String, superGlobal: Global) extends PluginComponent {
 
   override val global = superGlobal

--- a/plugin/src/main/scala/com/softwaremill/clippy/RestoreReporter.scala
+++ b/plugin/src/main/scala/com/softwaremill/clippy/RestoreReporter.scala
@@ -4,10 +4,10 @@ import scala.tools.nsc.plugins.PluginComponent
 import scala.tools.nsc.{Global, Phase}
 
 /**
-  * Replaces global reporter back with the original global reporter. Sbt uses its own xsbt.DelegatingReporter
-  * which we cannot replace outside of Scala compilation phases. This component makes sure that before the compilation
-  * is over, original reporter gets reassigned to the global field.
-  */
+ * Replaces global reporter back with the original global reporter. Sbt uses its own xsbt.DelegatingReporter
+ * which we cannot replace outside of Scala compilation phases. This component makes sure that before the compilation
+ * is over, original reporter gets reassigned to the global field.
+ */
 class RestoreReporter(val global: Global) extends PluginComponent {
 
   val originalReporter = global.reporter

--- a/plugin/src/main/scala/com/softwaremill/clippy/RestoreReporter.scala
+++ b/plugin/src/main/scala/com/softwaremill/clippy/RestoreReporter.scala
@@ -11,7 +11,7 @@ import scala.tools.nsc.{Global, Phase}
 class RestoreReporter(val global: Global) extends PluginComponent {
 
   val originalReporter = global.reporter
-
+  def isEnabled: Boolean = true
   override val runsAfter = List[String]("jvm")
   override val runsBefore = List[String]("terminal")
   override val phaseName = "restore-original-reporter"
@@ -23,7 +23,8 @@ class RestoreReporter(val global: Global) extends PluginComponent {
     override def description = "Switches the reporter from Clippy's DelegatingReporter back to original one"
 
     override def run(): Unit = {
-      global.reporter = originalReporter
+      if (isEnabled)
+        global.reporter = originalReporter
     }
   }
 


### PR DESCRIPTION
This PR enhances colored diff (#34).  Now it shrinks the common prefix/suffix, so a diff like:
--Lo--ng[String]
--Stri--ng[String]

should become
--Long--[String]
--String--[String]

Other minor changes in this PR:
* Documented the `testmode` option
* Disable custom reporter in test mode
* Fixed expanded types display in colored output advices