### PR TITLE
Use println to log info about new version

### DIFF
--- a/plugin/src/main/scala/com/softwaremill/clippy/AdviceLoader.scala
+++ b/plugin/src/main/scala/com/softwaremill/clippy/AdviceLoader.scala
@@ -77,7 +77,7 @@ class AdviceLoader(global: Global, url: String, localStoreDir: File, projectAdvi
           global.inform(s"Unable to load/store local Clippy advice due to: ${e.getMessage}")
           Clippy(ClippyBuildInfo.version, Nil)
       }
-      .andThen { case Success(v) => v.checkPluginVersion(ClippyBuildInfo.version, global.inform) }
+      .andThen { case Success(v) => v.checkPluginVersion(ClippyBuildInfo.version, println) }
 
   private def fetchStoreParseInBackground(): Future[Clippy] = {
     val f = fetchStoreParse()


### PR DESCRIPTION
Occasionally using global compiler throws an NPE here, probably due to some uninitialized logger underneath. This is a workaround applied until we find a better solution.