### PR TITLE
Added JBoss repository to workaround a bug in sbt-assembly

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,8 @@
 resolvers += Resolver.typesafeRepo("releases")
 
+// Workaround for the bug: https://github.com/sbt/sbt-assembly/issues/236
+resolvers += "JBoss" at "https://repository.jboss.org"
+
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.4.0")
 
 addSbtPlugin("com.updateimpact" % "updateimpact-sbt-plugin" % "2.1.1")


### PR DESCRIPTION
The bug is in sbt-assembly, and occurs when trying to open the project in IntelliJ IDEA, because it calls `sbt updateSbtClassifiers`